### PR TITLE
Stackscript support (fixes issue #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,11 @@ Successfully removed linode
 | `linode-image` | `LINODE_IMAGE` | `linode/ubuntu18.04` | The Linode Instance `image` which provides the Linux distribution (see [here](https://api.linode.com/v4/images)).
 | `linode-kernel` | `LINODE_KERNEL` | `linode/grub2` | The Linux Instance `kernel` to boot.  `linode/grub2` will defer to the distribution kernel. (see [here](https://api.linode.com/v4/linode/kernels) (`?page=N`))
 | `linode-ssh-port` | `LINODE_SSH_PORT` | `22` | The port that SSH is running on, needed for Docker Machine to provision the Linode.
+| `linode-ssh-user` | `LINODE_SSH_USER` | `root` | The user as which docker-machine should log in to the Linode instance to install Docker.  This user must have passwordless sudo.
 | `linode-docker-port` | `LINODE_DOCKER_PORT` | `2376` | The TCP port of the Linode that Docker will be listening on
 | `linode-swap-size` | `LINODE_SWAP_SIZE` | `512` | The amount of swap space provisioned on the Linode Instance
-
+| `linode-stackscript` | `LINODE_STACKSCRIPT` | None | Specifies the Linode StackScript to use to create the instance, either by numeric ID, or using the form *username*/*label*.
+| `linode-stackscript-data` | `LINODE_STACKSCRIPT_DATA` | None | A JSON string specifying data that is passed (via UDF) to the selected StackScript.
 
 ## Discussion / Help
 

--- a/pkg/drivers/linode/linode.go
+++ b/pkg/drivers/linode/linode.go
@@ -326,14 +326,14 @@ func (d *Driver) GetState() (state.State, error) {
 // Start a host
 func (d *Driver) Start() error {
 	log.Debug("Start...")
-	_, err := d.getClient().BootInstance(context.TODO(), d.InstanceID, 0)
+	err := d.getClient().BootInstance(context.TODO(), d.InstanceID, 0)
 	return err
 }
 
 // Stop a host gracefully
 func (d *Driver) Stop() error {
 	log.Debug("Stop...")
-	_, err := d.getClient().ShutdownInstance(context.TODO(), d.InstanceID)
+	err := d.getClient().ShutdownInstance(context.TODO(), d.InstanceID)
 	return err
 }
 
@@ -356,14 +356,14 @@ func (d *Driver) Remove() error {
 // have any special restart behaviour.
 func (d *Driver) Restart() error {
 	log.Debug("Restarting...")
-	_, err := d.getClient().RebootInstance(context.TODO(), d.InstanceID, 0)
+	err := d.getClient().RebootInstance(context.TODO(), d.InstanceID, 0)
 	return err
 }
 
 // Kill stops a host forcefully
 func (d *Driver) Kill() error {
 	log.Debug("Killing...")
-	_, err := d.getClient().ShutdownInstance(context.TODO(), d.InstanceID)
+	err := d.getClient().ShutdownInstance(context.TODO(), d.InstanceID)
 	return err
 }
 


### PR DESCRIPTION
This pull request adds support for two additional switches, namely `--linode-stackscript` and `--linode-stackscript-data`. The former takes a StackScript identifier, of the form _username_/_label_. The latter accepts a string containing JSON data that is passed to the StackScript via the UDF mechanism.

Note that if a StackScript is used to reconfigure `sshd` or to lock down the firewall, the user needs to bear in mind the StackScripts run before `docker-machine` has started installing Docker. Deployment will fail, for example, if the SSH port is changed without telling `docker-machine` the new port number, or if a firewall rule installed by the StackScript prevents `docker-machine` from logging in to the VPS.