### PR TITLE
Optimize workflows in CircleCI config.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,22 +33,13 @@ jobs:
       - run:
           name: Run goreleaser
           command: goreleaser
+
 workflows:
   version: 2
-  build:
+  main:
     jobs:
       - build:
           filters:
-            branches:
-              only: /.*/
-            tags:
-              ignore: /^v[0-9]+(\.[0-9]+)*/
-  build-and-release:
-    jobs:
-      - build:
-          filters:
-            branches:
-              ignore: /.*/
             tags:
               only: /^v[0-9]+(\.[0-9]+)*/
       - release:
@@ -59,4 +50,3 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v[0-9]+(\.[0-9]+)*/
-


### PR DESCRIPTION
CircleCI jobs build all branches by default and ignore all tags by default. Because of this, the workflow logic was a bit redundant.

This PR contains a Workflows config that does exactly the same as what this was already doing. No change in functionality. Just a much more concise config file.