### PR TITLE
Limit instance label length to 64 characters

### DIFF
--- a/pkg/drivers/linode/linode.go
+++ b/pkg/drivers/linode/linode.go
@@ -310,6 +310,10 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 		d.InstanceLabel = d.GetMachineName()
 	}
 
+	if len(d.InstanceLabel) > 64 {
+		d.InstanceLabel = d.InstanceLabel[0:64]
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Linode has a maximum length of 64 characters on instance labels, and requests that try to create labels longer than that will fail (see https://www.linode.com/docs/api/linode-instances/#linode-create__request-body-schema ).

This makes it impossible to use this driver to auto-scale GitLab runners on Linode, because when generating machine names, the GitLab docker-machine runner inserts a unique ID that ends up making the label longer than 64 characters.

This isn't a perfect solution, since it's possible the characters prior to index 64 might not be unique, but it works well enough for me and is the best solution I've thought of so far.  (aside from maybe hashing the machine name to produce a 64-character hash, which would lead to very ugly instance labels)

Signed-off-by: P. J. Reed <phillipreed@hatchbed.com>