### PR TITLE
fix: Normalize instance labels to match API validation standards

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/docker/machine v0.16.2
+	github.com/google/go-cmp v0.5.6
 	github.com/linode/linodego v1.2.1
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,7 @@ golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 h1:RqytpXGR1iVNX7psjB3ff8y7s
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/pkg/drivers/linode/linode_test.go
+++ b/pkg/drivers/linode/linode_test.go
@@ -1,7 +1,9 @@
 package linode
 
 import (
+	"github.com/google/go-cmp/cmp"
 	"net"
+	"reflect"
 	"testing"
 
 	"github.com/docker/machine/libmachine/drivers"
@@ -52,4 +54,18 @@ func TestIPInCIDR(t *testing.T) {
 	}
 	assert.True(t, ipInCIDR(tenOne, "10.0.0.0/8"), "10.0.0.1 is in 10.0.0.0/8")
 	assert.False(t, ipInCIDR(tenOne, "254.0.0.0/8"), "10.0.0.1 is not in 254.0.0.0/8")
+}
+
+func TestNormalizeInstanceLabel(t *testing.T) {
+	inputLabel := "_mycoollabel25';./__----=][[this,label,is,really[good]and]long[wow+that'scrazy[]what[a\\good!labelname."
+	expectedResult := "mycoollabel25._-thislabelisreallygoodandlongwowthatscrazywhatago"
+
+	result, err := normalizeInstanceLabel(inputLabel)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(result, expectedResult) {
+		t.Fatal(cmp.Diff(result, expectedResult))
+	}
 }


### PR DESCRIPTION
This pull request normalizes Linode instance labels (including machine names) to an acceptable format for instance creation. This is necessary as many tools (Rancher, etc.) have different machine name validation standards and must be adapted to the Linode label standard.

https://github.com/linode/rancher-ui-driver-linode/issues/2