### PR TITLE
Bump go version requirement to 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/linode/docker-machine-driver-linode
 
-go 1.17
+go 1.18
 
 require (
 	github.com/docker/machine v0.16.2


### PR DESCRIPTION
## 📝 Description

go 1.18 is required by the latest `linodego` which is the dependency of this project.