### PR TITLE
Fix typo

### DIFF
--- a/pkg/drivers/linode/linode.go
+++ b/pkg/drivers/linode/linode.go
@@ -158,7 +158,7 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 		mcnflag.StringFlag{
 			EnvVar: "LINODE_AUTHORIZED_USERS",
 			Name:   "linode-authorized-users",
-			Usage:  "Linode user accounts (seperated by commas) whose Linode SSH keys will be permitted root access to the created node",
+			Usage:  "Linode user accounts (separated by commas) whose Linode SSH keys will be permitted root access to the created node",
 		},
 		mcnflag.StringFlag{
 			EnvVar: "LINODE_LABEL",


### PR DESCRIPTION
Fix a typo reported on [go report](https://goreportcard.com/report/github.com/linode/docker-machine-driver-linode)