### PR TITLE
Remove usage of deprecated `io/ioutil`

### DIFF
--- a/pkg/drivers/linode/linode.go
+++ b/pkg/drivers/linode/linode.go
@@ -7,9 +7,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -584,7 +584,7 @@ func (d *Driver) createSSHKey() (string, error) {
 		return "", err
 	}
 
-	publicKey, err := ioutil.ReadFile(d.publicSSHKeyPath())
+	publicKey, err := os.ReadFile(d.publicSSHKeyPath())
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## 📝 Description

This is to remove the deprecated Golang package.