### PR TITLE
TPT-3778: Add explicit GitHub Actions permissions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,6 +12,10 @@ on:
       - '.github/labels.yml'
       - '.github/workflows/labeler.yml'
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   labeler:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [ published ]
 
+permissions:
+  contents: write
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 📝 Description

Add explicit least-privilege `GITHUB_TOKEN` permissions to the build, labeler, and release workflows.

This addresses code scanning alerts 1 through 4 for `actions/missing-workflow-permissions`. Read-only CI receives `contents: read`, label synchronization receives `contents: read` and `issues: write`, and GoReleaser receives `contents: write` to publish release assets.